### PR TITLE
Fix Module Loading Bug

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,15 @@
 # Change Log
 
+## v0.1.1
+
+- In new versions of Powershell if you load a module some text is output into 
+  the stream. Pywinrm doesn't handle this gracefully and it leaks into the 
+  stderr (https://github.com/diyan/pywinrm/issues/169). This version fixes
+  the issue by inserting `$ProgressPreference=false` at the beginning of the
+  powershell script that's being run.
+  
+  Contributed by Brad Bishop (Encore Technologies) #1
+
 ## v0.1.0
 
 Initial Revision

--- a/actions/lib/action.py
+++ b/actions/lib/action.py
@@ -255,12 +255,19 @@ class BaseAction(Action):
         """
         creds = self.resolve_creds(**kwargs)
         tport = self.resolve_transport(creds['connect'], **kwargs)
-        powershell = ''
+
+        """Has ProgressPreference=false because if the
+        attempts to load modules that progress is forwarded
+        into the stderr and causes the commands to fail.
+        There is an open pull request to pywinrm:
+        https://github.com/diyan/pywinrm/issues/169
+        """
+        powershell = '$ProgressPreference=false\n'
         cmdlet_args = kwargs['args'] if 'args' in kwargs else ''
         output_ps = self.resolve_output_ps(**kwargs)
 
         if 'username' in creds['cmdlet'] and 'password' in creds['cmdlet']:
-            powershell = ("$securepass = ConvertTo-SecureString \"{3}\" -AsPlainText -Force;\n"
+            powershell += ("$securepass = ConvertTo-SecureString \"{3}\" -AsPlainText -Force;\n"
                           "$admincreds = New-Object System.Management.Automation.PSCredential(\"{2}\", $securepass);\n"  # noqa
                           "{0} -Credential $admincreds {1}"
                           "").format(cmdlet,
@@ -268,7 +275,7 @@ class BaseAction(Action):
                                      creds['cmdlet']['username'],
                                      creds['cmdlet']['password'])
         else:
-            powershell = '{0} {1}'.format(cmdlet, cmdlet_args)
+            powershell += '{0} {1}'.format(cmdlet, cmdlet_args)
 
         # add output formatters to the powershell code
         powershell = output_ps.format(powershell)

--- a/actions/lib/action.py
+++ b/actions/lib/action.py
@@ -256,9 +256,10 @@ class BaseAction(Action):
         creds = self.resolve_creds(**kwargs)
         tport = self.resolve_transport(creds['connect'], **kwargs)
 
-        """Has ProgressPreference=false because if the
-        attempts to load modules that progress is forwarded
-        into the stderr and causes the commands to fail.
+        """Added ProgressPreference=false as first line
+        because if powershell attempts to load any modules
+        the progress of the module loading is then forwarded
+        into stderr and causes stackstorm to fail the call.
         There is an open pull request to pywinrm:
         https://github.com/diyan/pywinrm/issues/169
         """

--- a/pack.yaml
+++ b/pack.yaml
@@ -9,6 +9,6 @@ keywords:
     - active
     - directory
     - ad
-version: 0.1.0
+version: 0.1.1
 author: Encore Technologies
 email: code@encore.tech

--- a/tests/test_action_lib_baseaction.py
+++ b/tests/test_action_lib_baseaction.py
@@ -271,7 +271,7 @@ class TestActionLibBaseAction(ActiveDirectoryBaseActionTestCase):
 
         cmdlet = 'Test-Cmdlet'
         cmdlet_args = ''
-        powershell = "{0} {1}".format(cmdlet, cmdlet_args)
+        powershell = "$ProgressPreference=false\n{0} {1}".format(cmdlet, cmdlet_args)
         result = action.run_ad_cmdlet(cmdlet,
                                       credential_name='base',
                                       hostname='abc',
@@ -295,7 +295,7 @@ class TestActionLibBaseAction(ActiveDirectoryBaseActionTestCase):
 
         cmdlet = 'Test-Cmdlet'
         cmdlet_args = ''
-        powershell = "{0} {1}".format(cmdlet, cmdlet_args)
+        powershell = "$ProgressPreference=false\n{0} {1}".format(cmdlet, cmdlet_args)
         result = action.run_ad_cmdlet(cmdlet,
                                       credential_name='base',
                                       hostname='abc',
@@ -319,7 +319,8 @@ class TestActionLibBaseAction(ActiveDirectoryBaseActionTestCase):
 
         cmdlet = 'Test-Cmdlet'
         cmdlet_args = ''
-        powershell = ("$securepass = ConvertTo-SecureString \"{3}\" -AsPlainText -Force;\n"
+        powershell = ("$ProgressPreference=false\n"
+                      "$securepass = ConvertTo-SecureString \"{3}\" -AsPlainText -Force;\n"
                       "$admincreds = New-Object System.Management.Automation.PSCredential(\"{2}\", $securepass);\n"  # noqa
                       "{0} -Credential $admincreds {1}"
                       "").format(cmdlet,
@@ -350,7 +351,7 @@ class TestActionLibBaseAction(ActiveDirectoryBaseActionTestCase):
 
         cmdlet = 'Test-Cmdlet'
         cmdlet_args = ''
-        powershell = "{0} {1}".format(cmdlet, cmdlet_args)
+        powershell = "$ProgressPreference=false\n{0} {1}".format(cmdlet, cmdlet_args)
         powershell = self.get_output_ps_code('json').format(powershell)
         result = action.run_ad_cmdlet(cmdlet,
                                       credential_name='base',
@@ -411,7 +412,7 @@ class TestActionLibBaseAction(ActiveDirectoryBaseActionTestCase):
 
         cmdlet = 'Test-Cmdlet'
         cmdlet_args = ''
-        powershell = "{0} {1}".format(cmdlet, cmdlet_args)
+        powershell = "$ProgressPreference=false\n{0} {1}".format(cmdlet, cmdlet_args)
         powershell = self.get_output_ps_code('json').format(powershell)
         result = action.run_ad_cmdlet(cmdlet,
                                       credential_name='base',
@@ -438,7 +439,8 @@ class TestActionLibBaseAction(ActiveDirectoryBaseActionTestCase):
 
         cmdlet = 'Test-Cmdlet'
         cmdlet_args = ''
-        powershell = ("$securepass = ConvertTo-SecureString \"{3}\" -AsPlainText -Force;\n"
+        powershell = ("$ProgressPreference=false\n"
+                      "$securepass = ConvertTo-SecureString \"{3}\" -AsPlainText -Force;\n"
                       "$admincreds = New-Object System.Management.Automation.PSCredential(\"{2}\", $securepass);\n"  # noqa
                       "{0} -Credential $admincreds {1}"
                       "").format(cmdlet,

--- a/tests/test_action_lib_baseaction.py
+++ b/tests/test_action_lib_baseaction.py
@@ -271,7 +271,8 @@ class TestActionLibBaseAction(ActiveDirectoryBaseActionTestCase):
 
         cmdlet = 'Test-Cmdlet'
         cmdlet_args = ''
-        powershell = "$ProgressPreference=false\n{0} {1}".format(cmdlet, cmdlet_args)
+        powershell = ("$ProgressPreference=false\n"
+                      "{0} {1}").format(cmdlet, cmdlet_args)
         result = action.run_ad_cmdlet(cmdlet,
                                       credential_name='base',
                                       hostname='abc',
@@ -295,7 +296,8 @@ class TestActionLibBaseAction(ActiveDirectoryBaseActionTestCase):
 
         cmdlet = 'Test-Cmdlet'
         cmdlet_args = ''
-        powershell = "$ProgressPreference=false\n{0} {1}".format(cmdlet, cmdlet_args)
+        powershell = ("$ProgressPreference=false\n"
+                      "{0} {1}").format(cmdlet, cmdlet_args)
         result = action.run_ad_cmdlet(cmdlet,
                                       credential_name='base',
                                       hostname='abc',


### PR DESCRIPTION
In new versions of Powershell if you load a module some text is output into the stream. Pywinrm doesn't handle this gracefully and it leaks into the stderr (https://github.com/diyan/pywinrm/issues/169). This causes the pack to misbehave and believe an error has occurred when it really didn't.

This fix disables the print statements by inserting the `$ProgressPreference=false` statement at the beginning of the powershell script.