### PR TITLE
v1.0.1: Ensure stdout, stderr are not bytes objects.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## v1.0.1
+
+- Ensure stdout, stderr are not bytes objects.
+
 ## v1.0.0
 
 - Drop Python 2.7 support

--- a/actions/lib/action.py
+++ b/actions/lib/action.py
@@ -291,11 +291,21 @@ class BaseAction(Action):
 
         # run powershell command
         ps_result = self.connection.run_ps(powershell)
-        result = {'stdout': ps_result.std_out,
-                  'stderr': ps_result.std_err,
+
+        # Ensure stdout and stderr is always a string
+        stdout = ps_result.std_out
+        stderr = ps_result.std_err
+        if isinstance(stdout, bytes):
+            stdout = stdout.decode("utf-8")
+        if isinstance(stderr, bytes):
+            stderr = stderr.decode("utf-8")
+
+        result = {'stdout': stdout,
+                  'stderr': stderr,
                   'exit_status': ps_result.status_code,
-                  'stdout_dict': self.parse_output(ps_result.std_out, **kwargs),
-                  'stderr_dict': self.parse_output(ps_result.std_err, **kwargs)}
+                  'stdout_dict': self.parse_output(stdout, **kwargs),
+                  'stderr_dict': self.parse_output(stderr, **kwargs)}
+
 
         if result['exit_status'] == 0:
             return (True, result)

--- a/pack.yaml
+++ b/pack.yaml
@@ -9,7 +9,7 @@ keywords:
   - active
   - directory
   - ad
-version: 1.0.0
+version: 1.0.1
 author: Encore Technologies
 email: code@encore.tech
 python_versions:


### PR DESCRIPTION
Bug identified in slack:
https://stackstorm-community.slack.com/archives/C066APT88/p1649255925009179
